### PR TITLE
Include necessay header file

### DIFF
--- a/socks.h
+++ b/socks.h
@@ -7,6 +7,7 @@
 #include "buffer.h"
 #include <stdint.h>
 #include <stdlib.h>
+#include <sys/select.h>
 
 #define AE_NONE 0
 #define AE_READABLE 1


### PR DESCRIPTION
Fixes #4 `socks.h` contains some data type from `<sys/select>`.

 I think `gcc` may do some tricks causing ignoring the order of include headers while `clang` does not.
So when compiling `socks.c`, it works fine for `gcc`

``` C
#include "socks.h" // need data types from <sys/select.h>
#include "socket_wrap.h"  // already includes <sys/select.h>
```
