### PR TITLE
Simplify debug macro

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,4 @@
-debug = 1
-
-CFLAGS += -Wall
-ifeq ($(debug), 1)
-	CFLAGS += -O0 -DDEBUG=1 -g
-else
-	CFLAGS += -O2
-endif
+CFLAGS += -g -Wall -O0 -DDEBUG
 
 SRCDIR = .
 SRC := $(wildcard $(SRCDIR)/*.c)

--- a/debug.h
+++ b/debug.h
@@ -3,28 +3,13 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
-#include <assert.h>
-#include <errno.h>
 
-#if DEBUG
-#define DEBUG_PRINT         1
+#ifndef DEBUG
+#define debug_print(fmt, ...)
+#define DIE(fmt, ...)
 #else
-#define DEBUG_PRINT         0
+#define debug_print(fmt, ...) fprintf(stderr, "DEBUG %s:%d: %s():" fmt "\n", __FILE__, __LINE__, __func__, ##__VA_ARGS__)
+#define DIE(fmt, ...) { debug_print(fmt, ##__VA_ARGS__); exit(-1); }
 #endif
-
-#define debug_print(fmt, ...) \
-	do { \
-		if (DEBUG_PRINT) \
-			fprintf(stderr, "debug_print: %s: %d: %s():" \
-				fmt "\n", __FILE__, __LINE__, __func__, \
-				##__VA_ARGS__); \
-	} while (0)
-
-#define DIE(fmt, ...) \
-	do { \
-		debug_print(fmt, ##__VA_ARGS__); \
-		exit(-1); \
-	} while (0)
 
 #endif


### PR DESCRIPTION
From `#if DEBUG` to `#ifdef DEBUG`, We do not care the specific
value (0 or 1) of DEBUG, it is enough to know if it is defined or not.
