### PR TITLE
Revert "Simplify debug macro"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,11 @@
-CFLAGS += -g -Wall -O0 -DDEBUG
+debug = 1
+
+CFLAGS += -Wall
+ifeq ($(debug), 1)
+	CFLAGS += -O0 -DDEBUG=1 -g
+else
+	CFLAGS += -O2
+endif
 
 SRCDIR = .
 SRC := $(wildcard $(SRCDIR)/*.c)

--- a/debug.h
+++ b/debug.h
@@ -3,13 +3,28 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
+#include <assert.h>
+#include <errno.h>
 
-#ifndef DEBUG
-#define debug_print(fmt, ...)
-#define DIE(fmt, ...)
+#if DEBUG
+#define DEBUG_PRINT         1
 #else
-#define debug_print(fmt, ...) fprintf(stderr, "DEBUG %s:%d: %s():" fmt "\n", __FILE__, __LINE__, __func__, ##__VA_ARGS__)
-#define DIE(fmt, ...) { debug_print(fmt, ##__VA_ARGS__); exit(-1); }
+#define DEBUG_PRINT         0
 #endif
+
+#define debug_print(fmt, ...) \
+	do { \
+		if (DEBUG_PRINT) \
+			fprintf(stderr, "debug_print: %s: %d: %s():" \
+				fmt "\n", __FILE__, __LINE__, __func__, \
+				##__VA_ARGS__); \
+	} while (0)
+
+#define DIE(fmt, ...) \
+	do { \
+		debug_print(fmt, ##__VA_ARGS__); \
+		exit(-1); \
+	} while (0)
 
 #endif


### PR DESCRIPTION
Reverts hmgle/socks5_c#6
When not setting debug option, DIE() is a blank instruction, program recover from the errors which cause DIE() to terminate the program.
